### PR TITLE
Fix missing auth flow and import

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,36 +13,33 @@ void main() async {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  bool _showSignUp = false;
+
+  void _toggleScreen() {
+    setState(() {
+      _showSignUp = !_showSignUp;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const SignInScreen(
-        onSignUpTap: _showSignUpScreen,
-      ),
+      home: _showSignUp
+          ? SignUpScreen(onSignInTap: _toggleScreen)
+          : SignInScreen(onSignUpTap: _toggleScreen),
     );
   }
 }

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class UserModel {
   final String uid;
   final String email;


### PR DESCRIPTION
## Summary
- convert `MyApp` to a `StatefulWidget` to switch between sign‑in and sign‑up
- add missing Firestore import for `UserModel`

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5b2031908329bdaba8ba390b9eef