### PR TITLE
[scoopify-manager] Add user context management

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,13 +4,16 @@ import 'package:flutter/material.dart';
 import 'firebase_options.dart';
 import 'screens/sign_in_screen.dart';
 import 'screens/sign_up_screen.dart';
+import 'screens/home_screen.dart';
+import 'services/user_context.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  runApp(const MyApp());
+  final userNotifier = UserNotifier();
+  runApp(UserProvider(notifier: userNotifier, child: const MyApp()));
 }
 
 class MyApp extends StatefulWidget {
@@ -23,6 +26,12 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   bool _showSignUp = false;
 
+  void _handleSignOut() {
+    setState(() {
+      _showSignUp = false;
+    });
+  }
+
   void _toggleScreen() {
     setState(() {
       _showSignUp = !_showSignUp;
@@ -31,15 +40,18 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    final user = UserProvider.of(context).user;
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: _showSignUp
-          ? SignUpScreen(onSignInTap: _toggleScreen)
-          : SignInScreen(onSignUpTap: _toggleScreen),
+      home: user != null
+          ? HomeScreen(onSignOut: _handleSignOut)
+          : _showSignUp
+              ? SignUpScreen(onSignInTap: _toggleScreen)
+              : SignInScreen(onSignUpTap: _toggleScreen),
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import '../services/auth_service.dart';
+import '../services/user_context.dart';
+
+class HomeScreen extends StatelessWidget {
+  final VoidCallback onSignOut;
+  const HomeScreen({super.key, required this.onSignOut});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = UserProvider.of(context).user;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home'),
+        actions: [
+          IconButton(
+            onPressed: () async {
+              await AuthService().signOut();
+              UserProvider.of(context).clearUser();
+              onSignOut();
+            },
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
+      body: Center(
+        child: Text(user != null ? 'Welcome ${user.email}' : 'No user'),
+      ),
+    );
+  }
+}

--- a/lib/screens/sign_in_screen.dart
+++ b/lib/screens/sign_in_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import '../services/auth_service.dart';
+import '../services/storage_service.dart';
+import '../services/user_context.dart';
 
 class SignInScreen extends StatefulWidget {
   final VoidCallback onSignUpTap;
@@ -14,6 +16,7 @@ class _SignInScreenState extends State<SignInScreen> {
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   final AuthService _authService = AuthService();
+  final StorageService _storageService = StorageService();
   bool _loading = false;
   String? _error;
 
@@ -28,21 +31,10 @@ class _SignInScreenState extends State<SignInScreen> {
         _passwordController.text.trim(),
       );
       if (user != null) {
-        final userData = await _authService.getUserData(user.uid);
-        // For now, just show a dialog with user info
-        showDialog(
-          context: context,
-          builder: (_) => AlertDialog(
-            title: const Text('Welcome'),
-            content: Text(
-                'User: \\nEmail: \\${user.email}\\nData: \\${userData.toString()}'),
-            actions: [
-              TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('OK'))
-            ],
-          ),
-        );
+        final userModel = await _storageService.getUser(user.uid);
+        if (userModel != null) {
+          UserProvider.of(context).setUser(userModel);
+        }
       }
     } catch (e) {
       setState(() {

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import '../services/auth_service.dart';
+import '../services/storage_service.dart';
+import '../services/user_context.dart';
 
 class SignUpScreen extends StatefulWidget {
   final VoidCallback onSignInTap;
@@ -15,6 +17,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
   final TextEditingController _passwordController = TextEditingController();
   final TextEditingController _confirmController = TextEditingController();
   final AuthService _authService = AuthService();
+  final StorageService _storageService = StorageService();
   bool _loading = false;
   String? _error;
 
@@ -36,20 +39,10 @@ class _SignUpScreenState extends State<SignUpScreen> {
         _passwordController.text.trim(),
       );
       if (user != null) {
-        final userData = await _authService.getUserData(user.uid);
-        showDialog(
-          context: context,
-          builder: (_) => AlertDialog(
-            title: const Text('Registration Successful'),
-            content: Text(
-                'User: \nEmail: ${user.email}\nData: ${userData.toString()}'),
-            actions: [
-              TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('OK'))
-            ],
-          ),
-        );
+        final userModel = await _storageService.getUser(user.uid);
+        if (userModel != null) {
+          UserProvider.of(context).setUser(userModel);
+        }
       }
     } catch (e) {
       setState(() {

--- a/lib/services/user_context.dart
+++ b/lib/services/user_context.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+import '../models/user_model.dart';
+
+class UserNotifier extends ChangeNotifier {
+  UserModel? _user;
+
+  UserModel? get user => _user;
+
+  void setUser(UserModel? user) {
+    _user = user;
+    notifyListeners();
+  }
+
+  void clearUser() {
+    _user = null;
+    notifyListeners();
+  }
+}
+
+class UserProvider extends InheritedNotifier<UserNotifier> {
+  const UserProvider({Key? key, required UserNotifier notifier, required Widget child})
+      : super(key: key, notifier: notifier, child: child);
+
+  static UserNotifier of(BuildContext context) {
+    final provider = context.dependOnInheritedWidgetOfExactType<UserProvider>();
+    assert(provider != null, 'No UserProvider found in context');
+    return provider!.notifier!;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   firebase_core: ^3.13.1
+  firebase_auth: ^4.19.2
+  cloud_firestore: ^5.15.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create `UserNotifier` and `UserProvider` for global user access
- add `HomeScreen` to show user info and logout
- wire user context into sign in/up screens
- update app to switch to `HomeScreen` when logged in
- add required Firebase dependencies

## Testing
- `flutter pub get` *(fails: Proxy failed to establish tunnel (403 Forbidden))*
- `flutter analyze` *(fails: Proxy failed to establish tunnel (403 Forbidden))*
- `flutter test` *(fails: Proxy failed to establish tunnel (403 Forbidden))*


------
https://chatgpt.com/codex/tasks/task_e_683f760f28a483298327248ed1d86e91